### PR TITLE
accounts: implement ListAccounts

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -48,3 +48,28 @@ func Example_client_MyProfile() {
 
 	fmt.Printf("My profile: %+v\n", myProfile)
 }
+
+func Example_client_ListAccounts() {
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, err := client.ListAccounts(&coinbase.AccountsRequest{
+		MaxPage: 2,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for page := range res.PagesChan {
+		if err := page.Err; err != nil {
+			log.Printf("Page #%d err: %v", page.PageNumber, err)
+			continue
+		}
+
+		for i, account := range page.Accounts {
+			fmt.Printf("Page #%d:: (%d) Account: %#v\n", page.PageNumber, i, account)
+		}
+	}
+}

--- a/v2/accounts.go
+++ b/v2/accounts.go
@@ -1,0 +1,200 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coinbase
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/orijtech/otils"
+)
+
+type Account struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Primary  bool   `json:"primary"`
+	Type     string `json:"type"`
+	Currency string `json:"currency"`
+
+	Balance       *Balance `json:"balance"`
+	NativeBalance *Balance `json:"native_balance"`
+
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+
+type Balance struct {
+	Amount otils.NullableFloat64 `json:"amount"`
+
+	Currency string `json:"currency"`
+}
+
+func makeCanceler() (chan struct{}, func()) {
+	signaler := make(chan struct{}, 1)
+	var closeOnce sync.Once
+	fn := func() {
+		closeOnce.Do(func() { close(signaler) })
+	}
+	return signaler, fn
+}
+
+type AccountsRequest struct {
+	MaxPage int64 `json:"max_page"`
+
+	AccountsPerPage   int64  `json:"accounts_per_page"`
+	StartingAccountID string `json:"starting_account_id"`
+	EndingAccountID   string `json:"ending_account_id"`
+	OrderBy           string `json:"order_by"`
+
+	ThrottleDurationMs int64 `json:"throttle_duration_ms"`
+}
+
+const NoThrottle int64 = -1
+
+type AccountsPage struct {
+	Accounts   []*Account `json:"accounts"`
+	PageNumber int64      `json:"page_number"`
+
+	Err error `json:"error"`
+}
+
+var (
+	errEmptyAccountID = errors.New("expecting a non-empty accountID")
+)
+
+type pagination struct {
+	EndingBefore   otils.NullableString `json:"ending_before"`
+	StartingBefore otils.NullableString `json:"starting_before"`
+	Limit          int64                `json:"limit"`
+
+	PreviousURI otils.NullableString `json:"previous_uri"`
+	NextURI     otils.NullableString `json:"next_uri"`
+}
+
+type pageWrap struct {
+	Pagination *pagination `json:"pagination"`
+	Accounts   []*Account  `json:"data"`
+}
+
+func (c *Client) ListAccounts(req *AccountsRequest) (*AccountsListResponse, error) {
+	if req == nil {
+		req = new(AccountsRequest)
+	}
+
+	maxPage := req.MaxPage
+	pageExceeds := func(pageNumber int64) bool {
+		if maxPage <= 0 {
+			return false
+		}
+		return pageNumber > maxPage
+	}
+
+	pagesChan := make(chan *AccountsPage)
+
+	canceler, cancelFn := makeCanceler()
+
+	go func() {
+		defer close(pagesChan)
+
+		var throttleDuration time.Duration
+		if req.ThrottleDurationMs != NoThrottle && req.ThrottleDurationMs > 0 {
+			throttleDuration = 450 * time.Millisecond
+		}
+
+		queryValues := make(url.Values)
+		if limit := req.AccountsPerPage; limit > 0 {
+			queryValues.Set("limit", fmt.Sprintf("%d", limit))
+		}
+		if startAccountID := strings.TrimSpace(req.StartingAccountID); startAccountID != "" {
+			queryValues.Set("starting_after", startAccountID)
+		}
+		if endAccountID := strings.TrimSpace(req.EndingAccountID); endAccountID != "" {
+			queryValues.Set("ending_before", endAccountID)
+		}
+		if orderBy := req.OrderBy; orderBy != "" {
+			queryValues.Set("order", orderBy)
+		}
+
+		var nextURI otils.NullableString = "/v2/accounts"
+		if len(queryValues) > 0 {
+			nextURI = otils.NullableString(fmt.Sprintf("%s?%s", nextURI, queryValues.Encode()))
+		}
+
+		pageNumber := int64(0)
+
+		for {
+			fullURL := fmt.Sprintf("%s%s", unversionedBaseURL, nextURI)
+			page := new(AccountsPage)
+			page.PageNumber = pageNumber
+			req, err := http.NewRequest("GET", fullURL, nil)
+			if err != nil {
+				page.Err = err
+				pagesChan <- page
+				return
+			}
+			blob, _, err := c.doAuthAndReq(req)
+			if err != nil {
+				page.Err = err
+				pagesChan <- page
+				return
+			}
+			pWrap := new(pageWrap)
+			if err := json.Unmarshal(blob, pWrap); err != nil {
+				page.Err = err
+				pagesChan <- page
+				return
+			}
+			page.Accounts = pWrap.Accounts
+			pagesChan <- page
+
+			pageNumber += 1
+			if pageExceeds(pageNumber) || len(page.Accounts) == 0 {
+				return
+			}
+
+			nextURI = ""
+			if pWrap.Pagination != nil {
+				nextURI = pWrap.Pagination.NextURI
+			}
+
+			select {
+			case <-time.After(throttleDuration):
+			case <-canceler:
+				return
+			}
+			if nextURI == "" {
+				break
+			}
+		}
+	}()
+
+	res := &AccountsListResponse{
+		Cancel:    cancelFn,
+		PagesChan: pagesChan,
+	}
+
+	return res, nil
+}
+
+type AccountsListResponse struct {
+	PagesChan chan *AccountsPage
+	Cancel    func()
+}

--- a/v2/coinbase.go
+++ b/v2/coinbase.go
@@ -32,6 +32,8 @@ import (
 
 const (
 	baseURL = "https://api.coinbase.com/v2"
+
+	unversionedBaseURL = "https://api.coinbase.com"
 )
 
 type Client struct {

--- a/v2/testdata/accounts-page-0.json
+++ b/v2/testdata/accounts-page-0.json
@@ -1,0 +1,51 @@
+{
+  "pagination": {
+    "ending_before": null,
+    "starting_after": null,
+    "limit": 25,
+    "order": "desc",
+    "previous_uri": null,
+    "next_uri": "/v2/accounts?starting_after=75725f1b-25e4-48e3-b60e-43bc4f47188e&limit=25"
+  },
+  "data": [
+    {
+      "id": "58542935-67b5-56e1-a3f9-42686e07fa40",
+      "name": "My Vault",
+      "primary": false,
+      "type": "vault",
+      "currency": "BTC",
+      "balance": {
+        "amount": "4.00000000",
+        "currency": "BTC"
+      },
+      "native_balance": {
+        "amount": "40.00",
+        "currency": "USD"
+      },
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-01-31T20:49:02Z",
+      "resource": "account",
+      "resource_path": "/v2/accounts/58542935-67b5-56e1-a3f9-42686e07fa40",
+      "ready": true
+    },
+    {
+      "id": "2bbf394c-193b-5b2a-9155-3b4732659ede",
+      "name": "My Wallet",
+      "primary": true,
+      "type": "wallet",
+      "currency": "BTC",
+      "balance": {
+        "amount": "39.59000000",
+        "currency": "BTC"
+      },
+      "native_balance": {
+        "amount": "395.90",
+        "currency": "USD"
+      },
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-01-31T20:49:02Z",
+      "resource": "account",
+      "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede"
+    }
+  ]
+}

--- a/v2/testdata/accounts-page-1.json
+++ b/v2/testdata/accounts-page-1.json
@@ -1,0 +1,51 @@
+{
+  "pagination": {
+    "ending_before": null,
+    "starting_after": null,
+    "limit": 25,
+    "order": "desc",
+    "previous_uri": "/v2/accounts?ending_before=2bbf394c-193b-5b2a-9155-3b4732659ede",
+    "next_uri": "/v2/accounts?starting_after=f1d091ad-1736-4e48-81c4-9c868b64c7be&limit=25"
+  },
+  "data": [
+    {
+      "id": "58542935-67b5-56e1-a3f9-42686e07fa40",
+      "name": "My Vault",
+      "primary": false,
+      "type": "vault",
+      "currency": "BTC",
+      "balance": {
+        "amount": "4.20000000",
+        "currency": "BTC"
+      },
+      "native_balance": {
+        "amount": "40.00",
+        "currency": "USD"
+      },
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-01-31T20:49:02Z",
+      "resource": "account",
+      "resource_path": "/v2/accounts/58542935-67b5-56e1-a3f9-42686e07fa40",
+      "ready": true
+    },
+    {
+      "id": "9fca9fd7-02bb-43a6-b636-14c5fd99d3a4",
+      "name": "My Wallet",
+      "primary": true,
+      "type": "wallet",
+      "currency": "BTC",
+      "balance": {
+        "amount": "39.59000000",
+        "currency": "BTC"
+      },
+      "native_balance": {
+        "amount": "395.90",
+        "currency": "USD"
+      },
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-01-31T20:49:02Z",
+      "resource": "account",
+      "resource_path": "/v2/accounts/9fca9fd7-02bb-43a6-b636-14c5fd99d3a4"
+    }
+  ]
+}

--- a/v2/testdata/accounts-page-2.json
+++ b/v2/testdata/accounts-page-2.json
@@ -1,0 +1,51 @@
+{
+  "pagination": {
+    "ending_before": null,
+    "starting_after": null,
+    "limit": 25,
+    "order": "desc",
+    "previous_uri": "/v2/accounts?ending_before=9fca9fd7-02bb-43a6-b636-14c5fd99d3a4&limit=25",
+    "next_uri": null
+  },
+  "data": [
+    {
+      "id": "e223a032-1e4d-4301-b337-090d8d9a9d69",
+      "name": "My Vault",
+      "primary": false,
+      "type": "vault",
+      "currency": "BTC",
+      "balance": {
+        "amount": "4.00000000",
+        "currency": "BTC"
+      },
+      "native_balance": {
+        "amount": "40.00",
+        "currency": "USD"
+      },
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-01-31T20:49:02Z",
+      "resource": "account",
+      "resource_path": "/v2/accounts/e223a032-1e4d-4301-b337-090d8d9a9d69",
+      "ready": true
+    },
+    {
+      "id": "2bbf394c-193b-5b2a-9155-3b4732659ede",
+      "name": "My Wallet",
+      "primary": true,
+      "type": "wallet",
+      "currency": "BTC",
+      "balance": {
+        "amount": "39.59000000",
+        "currency": "BTC"
+      },
+      "native_balance": {
+        "amount": "395.90",
+        "currency": "USD"
+      },
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-01-31T20:49:02Z",
+      "resource": "account",
+      "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede"
+    }
+  ]
+}

--- a/v2/wallet.go
+++ b/v2/wallet.go
@@ -25,18 +25,6 @@ import (
 	"github.com/orijtech/otils"
 )
 
-type AccountsPage struct {
-}
-
-func (c *Client) ListAccounts() (chan *AccountsPage, error) {
-	pagesChan := make(chan *AccountsPage)
-	go func() {
-		defer close(pagesChan)
-	}()
-
-	return pagesChan, nil
-}
-
 type Profile struct {
 	ID        string `json:"id,omitempty"`
 	Username  string `json:"username,omitempty"`


### PR DESCRIPTION
Fixes #4.

Can now list accounts of the authenticated user.

Sample usage:
```go
package main

import (
	"fmt"
	"log"

	"github.com/orijtech/coinbase/v2"
)
func main() {
	client, err := coinbase.NewDefaultClient()
	if err != nil {
		log.Fatal(err)
	}

	res, err := client.ListAccounts(&coinbase.AccountsRequest{
		MaxPage: 2,
	})
	if err != nil {
		log.Fatal(err)
	}

	for page := range res.PagesChan {
		if err := page.Err; err != nil {
			log.Printf("Page #%d err: %v", page.PageNumber, err)
			continue
		}

		for i, account := range page.Accounts {
			fmt.Printf("Page #%d:: (%d) Account: %#v\n", page.PageNumber, i, account)
		}
	}
}
```