### PR TITLE
accounts: implement FindAccountByID

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -73,3 +73,15 @@ func Example_client_ListAccounts() {
 		}
 	}
 }
+
+func Example_client_FindAccountByID() {
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+	account, err := client.FindAccountByID("2bbf394c-193b-5b2a-9155-3b4732659ede")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("The account: %+v\n", account)
+}

--- a/v2/accounts.go
+++ b/v2/accounts.go
@@ -94,6 +94,31 @@ type pageWrap struct {
 	Accounts   []*Account  `json:"data"`
 }
 
+type accountWrap struct {
+	Account *Account `json:"data"`
+}
+
+func (c *Client) FindAccountByID(accountID string) (*Account, error) {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return nil, errEmptyAccountID
+	}
+	fullURL := fmt.Sprintf("%s/accounts/%s", baseURL, accountID)
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	blob, _, err := c.doAuthAndReq(req)
+	if err != nil {
+		return nil, err
+	}
+	aWrap := new(accountWrap)
+	if err := json.Unmarshal(blob, aWrap); err != nil {
+		return nil, err
+	}
+	return aWrap.Account, nil
+}
+
 func (c *Client) ListAccounts(req *AccountsRequest) (*AccountsListResponse, error) {
 	if req == nil {
 		req = new(AccountsRequest)

--- a/v2/testdata/account-2bbf394c-193b-5b2a-9155-3b4732659ede.json
+++ b/v2/testdata/account-2bbf394c-193b-5b2a-9155-3b4732659ede.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "id": "2bbf394c-193b-5b2a-9155-3b4732659ede",
+    "name": "My Wallet",
+    "primary": true,
+    "type": "wallet",
+    "currency": "BTC",
+    "balance": {
+      "amount": "39.59000000",
+      "currency": "BTC"
+    },
+    "native_balance": {
+      "amount": "395.90",
+      "currency": "USD"
+    },
+    "created_at": "2015-01-31T20:49:02Z",
+    "updated_at": "2015-01-31T20:49:02Z",
+    "resource": "account",
+    "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede"
+  }
+}


### PR DESCRIPTION
Fixes #5.

Implemented FindAccountByID

Sample usage:

```go
package main

import (
	"fmt"
	"log"

	"github.com/orijtech/coinbase/v2"
)

func main() {
	client, err := coinbase.NewDefaultClient()
	if err != nil {
		log.Fatal(err)
	}
	account, err := client.FindAccountByID("2bbf394c-193b-5b2a-9155-3b4732659ede")
	if err != nil {
		log.Fatal(err)
	}
	fmt.Printf("The account: %+v\n", account)
}
```