### PR TITLE
accounts: implemented CreateAccount

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -85,3 +85,19 @@ func Example_client_FindAccountByID() {
 	}
 	fmt.Printf("The account: %+v\n", account)
 }
+
+func Example_client_CreateAccount() {
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	createdAccount, err := client.CreateAccount(&coinbase.CreateAccountRequest{
+		Name: "Come As You Are",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Newly created account; %+v\n", createdAccount)
+}


### PR DESCRIPTION
Fixes #6.

Can now create an account with a Name.

Sample:
```go
package main

import (
  "fmt"
  "log"

  "github.com/orijtech/coinbase/v2"
)

func main() {
  client, err := coinbase.NewDefaultClient()
  if err != nil {
    log.Fatal(err)
  }

  createdAccount, err :=
client.CreateAccount(&coinbase.CreateAccountRequest{
    Name: "Come As You Are",
  })
  if err != nil {
    log.Fatal(err)
  }

  fmt.Printf("Newly created account; %+v\n", createdAccount)
}
```