### PR TITLE
accounts: implemented UpdateAccount

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -101,3 +101,20 @@ func Example_client_CreateAccount() {
 
 	fmt.Printf("Newly created account; %+v\n", createdAccount)
 }
+
+func Example_client_UpdateAccount() {
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	updatedAccount, err := client.UpdateAccount(&coinbase.UpdateAccountRequest{
+		Name: "Main BTC Wallet",
+		ID:   "82de7fcd-db72-5085-8ceb-bee19303080b",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Updated account; %+v\n", updatedAccount)
+}

--- a/v2/accounts.go
+++ b/v2/accounts.go
@@ -112,6 +112,37 @@ func (creq *CreateAccountRequest) Validate() error {
 	return nil
 }
 
+type UpdateAccountRequest struct {
+	Name string `json:"name"`
+	ID   string `json:"account_id"`
+}
+
+func (ureq *UpdateAccountRequest) Validate() error {
+	if ureq == nil || strings.TrimSpace(ureq.ID) == "" {
+		return errEmptyAccountID
+	}
+	if strings.TrimSpace(ureq.Name) == "" {
+		return errBlankName
+	}
+	return nil
+}
+
+func (c *Client) UpdateAccount(ureq *UpdateAccountRequest) (*Account, error) {
+	if err := ureq.Validate(); err != nil {
+		return nil, err
+	}
+	fullURL := fmt.Sprintf("%s/accounts/%s", baseURL, ureq.ID)
+	blob, err := json.Marshal(map[string]string{"name": ureq.Name})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("PUT", fullURL, bytes.NewReader(blob))
+	if err != nil {
+		return nil, err
+	}
+	return c.authAndRetrieveAccount(req)
+}
+
 func (c *Client) CreateAccount(creq *CreateAccountRequest) (*Account, error) {
 	if err := creq.Validate(); err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #8

Can now update an account's name -- the only functionality
for the API.

Sample usage:
```go
package main

import (
	"fmt"
	"log"

	"github.com/orijtech/coinbase/v2"
)

func main() {
	client, err := coinbase.NewDefaultClient()
	if err != nil {
		log.Fatal(err)
	}

	updatedAccount, err := client.UpdateAccount(&coinbase.UpdateAccountRequest{
		Name: "Main BTC Wallet",
		ID:   "82de7fcd-db72-5085-8ceb-bee19303080b",
	})
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Updated account; %+v\n", updatedAccount)
}
```