### PR TITLE
accounts: implemented DeleteAccountByID

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -118,3 +118,14 @@ func Example_client_UpdateAccount() {
 
 	fmt.Printf("Updated account; %+v\n", updatedAccount)
 }
+
+func Example_client_DeleteAccountByID() {
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := client.DeleteAccountByID("82de7fcd-db72-5085-8ceb-bee19303080b"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/v2/accounts.go
+++ b/v2/accounts.go
@@ -159,6 +159,20 @@ func (c *Client) CreateAccount(creq *CreateAccountRequest) (*Account, error) {
 	return c.authAndRetrieveAccount(req)
 }
 
+func (c *Client) DeleteAccountByID(accountID string) error {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return errEmptyAccountID
+	}
+	fullURL := fmt.Sprintf("%s/accounts/%s", baseURL, accountID)
+	req, err := http.NewRequest("DELETE", fullURL, nil)
+	if err != nil {
+		return err
+	}
+	_, _, err = c.doAuthAndReq(req)
+	return err
+}
+
 func (c *Client) FindAccountByID(accountID string) (*Account, error) {
 	accountID = strings.TrimSpace(accountID)
 	if accountID == "" {

--- a/v2/coinbase.go
+++ b/v2/coinbase.go
@@ -159,7 +159,10 @@ func (c *Client) doHTTPReq(req *http.Request) ([]byte, http.Header, error) {
 	}
 
 	if otils.StatusOK(res.StatusCode) {
-		slurp, err := ioutil.ReadAll(res.Body)
+		var slurp []byte
+		if res.Body != nil {
+			slurp, err = ioutil.ReadAll(res.Body)
+		}
 		return slurp, res.Header, err
 	}
 


### PR DESCRIPTION
Fixes #9.

Implemented a method to delete an account by ID.

* Exhibit:

```go
package main

import (
  "fmt"
  "log"

  "github.com/orijtech/coinbase/v2"
)

func main() {
  client, err := coinbase.NewDefaultClient()
  if err != nil {
    log.Fatal(err)
  }

  if err :=
client.DeleteAccountByID("82de7fcd-db72-5085-8ceb-bee19303080b"); err !=
nil {
    log.Fatal(err)
  }
}
```