### PR TITLE
accounts: implemented SetAccountAsPrimary

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -129,3 +129,17 @@ func Example_client_DeleteAccountByID() {
 		log.Fatal(err)
 	}
 }
+
+func Example_client_SetAccountAsPrimary() {
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	updatedAccount, err := client.SetAccountAsPrimary("82de7fcd-db72-5085-8ceb-bee19303080b")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Updated account; %+v\n", updatedAccount)
+}

--- a/v2/accounts.go
+++ b/v2/accounts.go
@@ -159,6 +159,19 @@ func (c *Client) CreateAccount(creq *CreateAccountRequest) (*Account, error) {
 	return c.authAndRetrieveAccount(req)
 }
 
+func (c *Client) SetAccountAsPrimary(accountID string) (*Account, error) {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return nil, errEmptyAccountID
+	}
+	fullURL := fmt.Sprintf("%s/accounts/%s/primary", baseURL, accountID)
+	req, err := http.NewRequest("POST", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.authAndRetrieveAccount(req)
+}
+
 func (c *Client) DeleteAccountByID(accountID string) error {
 	accountID = strings.TrimSpace(accountID)
 	if accountID == "" {


### PR DESCRIPTION
Fixes #7.

Added the ability for an account to be set as the primary.

* Exhibit:
```go
package main

import (
	"fmt"
	"log"

	"github.com/orijtech/coinbase/v2"
)

func main() {
	client, err := coinbase.NewDefaultClient()
	if err != nil {
		log.Fatal(err)
	}

	updatedAccount, err := client.SetAccountAsPrimary("82de7fcd-db72-5085-8ceb-bee19303080b")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Updated account; %+v\n", updatedAccount)
}
``