### PR TITLE
addresses: implemented List and Create

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -143,3 +143,46 @@ func Example_client_SetAccountAsPrimary() {
 
 	fmt.Printf("Updated account; %+v\n", updatedAccount)
 }
+
+func Example_client_CreateAddress() {
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	address, err := client.CreateAddress(&coinbase.CreateAddressRequest{
+		AccountID: "82de7fcd-db72-5085-8ceb-bee19303080b",
+		Name:      "Ethereum-Account",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Created address: %#v\n", address)
+}
+
+func Example_client_ListAddresses() {
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, err := client.ListAddresses(&coinbase.AddressesRequest{
+		AccountID:        "82de7fcd-db72-5085-8ceb-bee19303080b",
+		AddressesPerPage: 1,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for page := range res.PagesChan {
+		if err := page.Err; err != nil {
+			log.Printf("Page #%d err: %v", page.PageNumber, err)
+			continue
+		}
+
+		for i, address := range page.Addresses {
+			fmt.Printf("Page #%d:: (%d) Account: %#v\n", page.PageNumber, i, address)
+		}
+	}
+}

--- a/v2/address-1.json
+++ b/v2/address-1.json
@@ -1,0 +1,10 @@
+{
+      "id": "dd3183eb-af1d-5f5d-a90d-cbff946435ff",
+      "address": "mswUGcPHp1YnkLCgF1TtoryqSc5E9Q8xFa",
+      "name": null,
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-03-31T17:25:29-07:00",
+      "network": "bitcoin",
+      "resource": "address",
+      "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede/addresses/dd3183eb-af1d-5f5d-a90d-cbff946435ff"
+}

--- a/v2/addresses.go
+++ b/v2/addresses.go
@@ -1,0 +1,213 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coinbase
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/orijtech/otils"
+)
+
+type Address struct {
+	ID      string `json:"id"`
+	Address string `json:"address"`
+
+	// Name is the user defined label for the address.
+	Name otils.NullableString `json:"name"`
+
+	// Network is the name of the blockchain.
+	Network otils.NullableString `json:"network"`
+
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+
+type AddressPage struct {
+	PageNumber int64      `json:"page_number"`
+	Addresses  []*Address `json:"addresses"`
+	Err        error
+}
+
+type AddressesResponse struct {
+	PagesChan chan *AddressPage `json:"page"`
+	Cancel    func()
+}
+
+type AddressesRequest struct {
+	AccountID string `json:"account_id"`
+
+	MaxPage int64 `json:"max_page"`
+
+	AddressesPerPage  int64  `json:"addresses_per_page"`
+	StartingAddressID string `json:"starting_address_id"`
+	EndingAddressID   string `json:"ending_address_id"`
+	OrderBy           string `json:"order_by"`
+
+	ThrottleDurationMs int64 `json:"throttle_duration_ms"`
+}
+
+func (alReq *AddressesRequest) Validate() error {
+	if alReq == nil || strings.TrimSpace(alReq.AccountID) == "" {
+		return errEmptyAccountID
+	}
+	return nil
+}
+
+type addressesPageWrap struct {
+	Pagination *pagination `json:"pagination"`
+	Addresses  []*Address  `json:"data"`
+}
+
+func (c *Client) ListAddresses(alReq *AddressesRequest) (*AddressesResponse, error) {
+	if err := alReq.Validate(); err != nil {
+		return nil, err
+	}
+
+	pagesChan := make(chan *AddressPage)
+	pageExceeds := maxPageChecker(alReq.MaxPage)
+	canceler, cancelFn := makeCanceler()
+
+	go func() {
+		defer close(pagesChan)
+
+		var throttleDuration time.Duration
+		if alReq.ThrottleDurationMs != NoThrottle && alReq.ThrottleDurationMs > 0 {
+			throttleDuration = time.Duration(alReq.ThrottleDurationMs) * time.Millisecond
+		}
+
+		queryValues := make(url.Values)
+		if limit := alReq.AddressesPerPage; limit > 0 {
+			queryValues.Set("limit", fmt.Sprintf("%d", limit))
+		}
+		if startAddressID := strings.TrimSpace(alReq.StartingAddressID); startAddressID != "" {
+			queryValues.Set("starting_after", startAddressID)
+		}
+		if endAddressID := strings.TrimSpace(alReq.EndingAddressID); endAddressID != "" {
+			queryValues.Set("ending_before", endAddressID)
+		}
+		if orderBy := alReq.OrderBy; orderBy != "" {
+			queryValues.Set("order", orderBy)
+		}
+
+		nextURI := otils.NullableString(fmt.Sprintf("/v2/accounts/%s/addresses", alReq.AccountID))
+		if len(queryValues) > 0 {
+			nextURI = otils.NullableString(fmt.Sprintf("%s?%s", nextURI, queryValues.Encode()))
+		}
+
+		pageNumber := int64(0)
+
+		for {
+			fullURL := fmt.Sprintf("%s%s", unversionedBaseURL, nextURI)
+			page := new(AddressPage)
+			page.PageNumber = pageNumber
+			req, err := http.NewRequest("GET", fullURL, nil)
+			if err != nil {
+				page.Err = err
+				pagesChan <- page
+				return
+			}
+			blob, _, err := c.doAuthAndReq(req)
+			if err != nil {
+				page.Err = err
+				pagesChan <- page
+				return
+			}
+			pWrap := new(addressesPageWrap)
+			if err := json.Unmarshal(blob, pWrap); err != nil {
+				page.Err = err
+				pagesChan <- page
+				return
+			}
+			page.Addresses = pWrap.Addresses
+			pagesChan <- page
+
+			pageNumber += 1
+			if pageExceeds(pageNumber) || len(page.Addresses) == 0 {
+				return
+			}
+
+			nextURI = ""
+			if pWrap.Pagination != nil {
+				nextURI = pWrap.Pagination.NextURI
+			}
+
+			select {
+			case <-time.After(throttleDuration):
+			case <-canceler:
+				return
+			}
+			if nextURI == "" {
+				break
+			}
+		}
+	}()
+
+	res := &AddressesResponse{
+		Cancel:    cancelFn,
+		PagesChan: pagesChan,
+	}
+
+	return res, nil
+}
+
+type CreateAddressRequest struct {
+	AccountID string `json:"account_id"`
+
+	// Name is optional if you are
+	// creating an address on demand.
+	Name string `json:"name"`
+}
+
+func (caReq *CreateAddressRequest) Validate() error {
+	if caReq == nil || strings.TrimSpace(caReq.AccountID) == "" {
+		return errEmptyAccountID
+	}
+	return nil
+}
+
+type addressWrap struct {
+	Address *Address `json:"data"`
+}
+
+func (c *Client) CreateAddress(caReq *CreateAddressRequest) (*Address, error) {
+	if err := caReq.Validate(); err != nil {
+		return nil, err
+	}
+	blob, err := json.Marshal(map[string]string{"name": caReq.Name})
+	if err != nil {
+		return nil, err
+	}
+	fullURL := fmt.Sprintf("%s/accounts/%s/addresses", baseURL, caReq.AccountID)
+	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(blob))
+	if err != nil {
+		return nil, err
+	}
+
+	blob, _, err = c.doAuthAndReq(req)
+	if err != nil {
+		return nil, err
+	}
+	aWrap := new(addressWrap)
+	if err := json.Unmarshal(blob, aWrap); err != nil {
+		return nil, err
+	}
+	return aWrap.Address, nil
+}

--- a/v2/coinbase.go
+++ b/v2/coinbase.go
@@ -122,7 +122,11 @@ func (c *Client) hmacSignature(req *http.Request, timestampUnix int64) string {
 	}
 
 	mac := hmac.New(sha256.New, []byte(c.apiSecret))
-	sig := fmt.Sprintf("%d%s%s%s", timestampUnix, req.Method, req.URL.Path, body)
+	urlPath := req.URL.Path
+	if q := req.URL.Query(); len(q) > 0 {
+		urlPath += "?" + q.Encode()
+	}
+	sig := fmt.Sprintf("%d%s%s%s", timestampUnix, req.Method, urlPath, body)
 	mac.Write([]byte(sig))
 	return fmt.Sprintf("%x", mac.Sum(nil))
 }

--- a/v2/testdata/1-addresses.json
+++ b/v2/testdata/1-addresses.json
@@ -1,0 +1,32 @@
+{
+  "pagination": {
+    "ending_before": null,
+    "starting_after": null,
+    "limit": 25,
+    "order": "desc",
+    "previous_uri": null,
+    "next_uri": null
+  },
+  "data": [
+    {
+      "id": "dd3183eb-af1d-5f5d-a90d-cbff946435ff",
+      "address": "mswUGcPHp1YnkLCgF1TtoryqSc5E9Q8xFa",
+      "name": null,
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-03-31T17:25:29-07:00",
+      "network": "bitcoin",
+      "resource": "address",
+      "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede/addresses/dd3183eb-af1d-5f5d-a90d-cbff946435ff"
+    },
+    {
+      "id": "ac5c5f15-0b1d-54f5-8912-fecbf66c2a64",
+      "address": "mgSvu1z1amUFAPkB4cUg8ujaDxKAfZBt5Q",
+      "name": null,
+      "created_at": "2015-03-31T17:23:52-07:00",
+      "updated_at": "2015-01-31T20:49:02Z",
+      "network": "bitcoin",
+      "resource": "address",
+      "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede/addresses/ac5c5f15-0b1d-54f5-8912-fecbf66c2a64"
+    }
+  ]
+}

--- a/v2/testdata/address-dd3183eb-af1d-5f5d-a90d-cbff946435ff.json
+++ b/v2/testdata/address-dd3183eb-af1d-5f5d-a90d-cbff946435ff.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+      "id": "dd3183eb-af1d-5f5d-a90d-cbff946435ff",
+      "address": "mswUGcPHp1YnkLCgF1TtoryqSc5E9Q8xFa",
+      "name": null,
+      "created_at": "2015-01-31T20:49:02Z",
+      "updated_at": "2015-03-31T17:25:29-07:00",
+      "network": "bitcoin",
+      "resource": "address",
+      "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede/addresses/dd3183eb-af1d-5f5d-a90d-cbff946435ff"
+  }
+}


### PR DESCRIPTION
Fixes #16.
Fixes #17.

Now have client methods to List and Create addresses
for an account.

* Exhibit:
+ ListAddresses:
```go
func listAddresses() {
	client, err := coinbase.NewDefaultClient()
	if err != nil {
		log.Fatal(err)
	}

	res, err := client.ListAddresses(&coinbase.AddressesRequest{
		AccountID:        "82de7fcd-db72-5085-8ceb-bee19303080b",
		AddressesPerPage: 1,
	})
	if err != nil {
		log.Fatal(err)
	}

	for page := range res.PagesChan {
		if err := page.Err; err != nil {
			log.Printf("Page #%d err: %v", page.PageNumber, err)
			continue
		}

		for i, address := range page.Addresses {
			fmt.Printf("Page #%d:: (%d) Account: %#v\n", page.PageNumber, i, address)
		}
	}
}
```

+ CreateAddress:
```go
func createAddress() {
	client, err := coinbase.NewDefaultClient()
	if err != nil {
		log.Fatal(err)
	}

	address, err := client.CreateAddress(&coinbase.CreateAddressRequest{
		AccountID: "82de7fcd-db72-5085-8ceb-bee19303080b",
		Name:      "Ethereum-Account",
	})
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Created address: %#v\n", address)
}
```