### PR TITLE
cmd/gdax-trades-ago: a util to dump a CSV of trades

### DIFF
--- a/cmd/gdax-trades-ago/README.md
+++ b/cmd/gdax-trades-ago/README.md
@@ -1,0 +1,29 @@
+# gdax-trades-ago
+
+## Installing it
+```shell
+go get -u github.com/orijtech/coinbbase/cmd/gdax-trades-ago
+```
+
+## Using it
+You can optionally set:
+* dur-ago: The duration to go back behind. Duration values are defined at https://golang.org/pkg/time/#ParseDuration
+So valid dur-ago suffixes are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+For example: -dur-ago 86h20m
+* product: The <from>-<to> currency pair defined at https://docs.gdax.com/#get-products
+For example: -product BTC-USD
+
+```shell
+gdax-trades-ago -dur-ago 2h -product BTC-USD && head -n 10 data.csv 
+2017/09/21 21:47:42 Flushed page: #1
+data,timeEpoch,high,low,open,close,volume
+2017-09-21T18:47:00.00000Z,1506041220,3643.6000,3643.6000,3643.6000,3643.6000,0.9226
+2017-09-21T18:46:00.00000Z,1506041160,3643.5900,3643.9900,3643.5900,3643.6000,5.9599
+2017-09-21T18:45:00.00000Z,1506041100,3643.5900,3644.0000,3644.0000,3643.9600,2.5004
+2017-09-21T18:44:00.00000Z,1506041040,3643.9900,3644.0000,3644.0000,3644.0000,2.1227
+2017-09-21T18:43:00.00000Z,1506040980,3644.0000,3644.1600,3644.1600,3644.0000,5.6206
+2017-09-21T18:42:00.00000Z,1506040920,3642.1200,3644.5800,3644.5800,3644.1600,6.1915
+2017-09-21T18:41:00.00000Z,1506040860,3640.8400,3646.6100,3646.6100,3644.5800,8.6110
+2017-09-21T18:40:00.00000Z,1506040800,3646.6000,3647.0500,3647.0500,3646.6100,5.5431
+2017-09-21T18:39:00.00000Z,1506040740,3647.0000,3649.8500,3649.7000,3647.0500,6.2359
+```

--- a/cmd/gdax-trades-ago/main.go
+++ b/cmd/gdax-trades-ago/main.go
@@ -1,0 +1,82 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/orijtech/coinbase/v2"
+)
+
+func main() {
+	var durationAgo string
+	var product string
+	flag.StringVar(&durationAgo, "dur-ago", "8760h", "the duration ago to go back to")
+	flag.StringVar(&product, "product", "ETH-USD", "the product to retrieve trades for")
+	flag.Parse()
+
+	now := time.Now()
+	pastDuration, err := time.ParseDuration(durationAgo)
+	if err != nil || pastDuration <= 0 {
+		pastDuration = 365 * 24 * time.Hour
+	}
+
+	client, err := coinbase.NewDefaultClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	csres, err := client.CandleSticks(&coinbase.CandleStickRequest{
+		Product:   product,
+		StartTime: now.Add(-1 * pastDuration),
+		EndTime:   now,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	f, err := os.Create("data.csv")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "data,timeEpoch,high,low,open,close,volume\n")
+	bw := bufio.NewWriter(f)
+	defer bw.Flush()
+
+	for csPage := range csres.PagesChan {
+		if csPage.Err != nil {
+			log.Printf("PageNumber #%d err: %v", csPage.PageNumber, csPage.Err)
+			continue
+		}
+		if len(csPage.CandleSticks) == 0 {
+			continue
+		}
+		for _, cs := range csPage.CandleSticks {
+			ts := int64(cs.Time)
+			t := time.Unix(ts, 0)
+			iso8601 := t.Format("2006-01-02T15:04:05.00000Z")
+			fmt.Fprintf(bw, "%s,%d,%.4f,%.4f,%.4f,%.4f,%.4f\n", iso8601, ts, cs.High, cs.Low, cs.Open, cs.Close, cs.Volume)
+		}
+		bw.Flush()
+		log.Printf("Flushed page: #%d", csPage.PageNumber)
+	}
+}


### PR DESCRIPTION
A utility to dump out a CSV of past trades

Sample
```shell
$ gdax-trades-ago -dur-ago 2h -product BTC-USD && head -n 10 data.csv
2017/09/21 21:50:02 Flushed page: #1
data,timeEpoch,high,low,open,close,volume
2017-09-21T18:50:00.00000Z,1506041400,3643.6000,3643.6000,3643.6000,3643.6000,0.0003
2017-09-21T18:49:00.00000Z,1506041340,3643.6000,3643.6000,3643.6000,3643.6000,1.3807
2017-09-21T18:48:00.00000Z,1506041280,3643.5900,3643.6000,3643.6000,3643.6000,8.9797
2017-09-21T18:47:00.00000Z,1506041220,3643.6000,3643.6000,3643.6000,3643.6000,0.9226
2017-09-21T18:46:00.00000Z,1506041160,3643.5900,3643.9900,3643.5900,3643.6000,5.9599
2017-09-21T18:45:00.00000Z,1506041100,3643.5900,3644.0000,3644.0000,3643.9600,2.5004
2017-09-21T18:44:00.00000Z,1506041040,3643.9900,3644.0000,3644.0000,3644.0000,2.1227
2017-09-21T18:43:00.00000Z,1506040980,3644.0000,3644.1600,3644.1600,3644.0000,5.6206
2017-09-21T18:42:00.00000Z,1506040920,3642.1200,3644.5800,3644.5800,3644.1600,6.1915
```