### PR TITLE
v2: support and filter currency pair lookups

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -193,7 +193,7 @@ func Example_client_ExchangeRate() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	from := coinbase.BTC
+	from := coinbase.Currency("BTC-USD-ETH")
 	ratesResp, err := client.ExchangeRate(from)
 	if err != nil {
 		log.Fatalf("exchangeRate err: %v", err)

--- a/v2/coinbase_test.go
+++ b/v2/coinbase_test.go
@@ -1005,7 +1005,7 @@ func (b *backend) badAuthCheck(req *http.Request) *http.Response {
 	return nil
 }
 
-func TestExchange(t *testing.T) {
+func TestExchangeRate(t *testing.T) {
 	rt := &backend{route: exchangeRateRoute}
 	tests := [...]struct {
 		from    coinbase.Currency
@@ -1013,8 +1013,9 @@ func TestExchange(t *testing.T) {
 	}{
 		0: {coinbase.USD, false},
 		1: {"unknown", true},
-		2: {coinbase.LTC, false},
-		3: {"", false}, // Must return the default currency
+		2: {"LTC-USD", false},
+		3: {"LTC-USD-BTC-ETH", false},
+		4: {"", false}, // Must return the default currency
 	}
 	client := new(coinbase.Client)
 	client.SetHTTPRoundTripper(rt)

--- a/v2/trades.go
+++ b/v2/trades.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/orijtech/otils"
 	"github.com/odeke-em/semalim"
+	"github.com/orijtech/otils"
 )
 
 type CandleStickRequest struct {


### PR DESCRIPTION
GDAX rate lookups are single currency which returns
a map of all currencies to that particular one e.g
Naturally, the following aren't valid lookups:
* ETH-USD
* LTC-USD-BTC
* BTC-USD-LTC
However, for a better API, now permit looking up
just currency pairs. After a result is returned, prune
out the non-secondary pairs and only return the secondaries

For example
* ETH-USD-BTC
will only return
{
  "from": "ETH",
  "rates": {
    "USD": XXXX,
    "BTC": YYYY
  }
}