### PR TITLE
v2/order: ensure that Side is set

### DIFF
--- a/v2/coinbase_test.go
+++ b/v2/coinbase_test.go
@@ -1099,14 +1099,20 @@ func TestOrder(t *testing.T) {
 	}{
 		0: {nil, key1, "non-blank product"},
 		1: {&coinbase.Order{}, key1, "non-blank product"},
-		2: {&coinbase.Order{Product: "BTC-USD"}, key1, "price to have been set"},
-		3: {&coinbase.Order{Product: "BTC-USD", Price: 100}, key1, ""},
-		4: {&coinbase.Order{Product: "BTC-USD", Price: 100}, nil, "Unauthorized"},
-		5: {&coinbase.Order{Product: "Fake-Product", Price: 100}, key1, "no such"},
+		2: {&coinbase.Order{Product: "BTC-USD"}, key1, "either price or size to have been set"},
+		3: {
+			&coinbase.Order{Product: "BTC-USD", Price: 100, Side: coinbase.SideSell}, key1, "",
+		},
+		4: {&coinbase.Order{Side: coinbase.SideBuy, Product: "BTC-USD", Price: 100}, nil, "Unauthorized"},
+		5: {
+			&coinbase.Order{Product: "Fake-Product", Side: coinbase.SideSell, Price: 100},
+			key1, "no such",
+		},
 		6: {
 			&coinbase.Order{
 				Product:     "BTC-USD",
 				Price:       100,
+				Side:        coinbase.SideSell,
 				CancelAfter: coinbase.Day,
 			},
 			key1, "to be GTT",
@@ -1114,7 +1120,8 @@ func TestOrder(t *testing.T) {
 		7: {
 			&coinbase.Order{
 				Product:     "BTC-USD",
-				Price:       100,
+				Size:        94.5,
+				Side:        coinbase.SideBuy,
 				TimeInForce: coinbase.GTT,
 				CancelAfter: coinbase.Day,
 			},

--- a/v2/order.go
+++ b/v2/order.go
@@ -175,7 +175,9 @@ type Order struct {
 }
 
 var (
-	errBlankPrice = errors.New("expecting price to have been set")
+	errBlankPriceOrSize = errors.New("expecting either price or size to have been set")
+
+	errBlankSide = errors.New("expecting side to be set")
 
 	errCancelAfterWithoutGTT = errors.New("CancelAfter if set requires TimeInForce to be GTT")
 )
@@ -184,8 +186,11 @@ func (o *Order) Validate() error {
 	if o == nil || o.Product == "" {
 		return errBlankProduct
 	}
-	if o.Price <= 0 {
-		return errBlankPrice
+	if o.Price <= 0 && o.Size <= 0 {
+		return errBlankPriceOrSize
+	}
+	if o.Side == "" {
+		return errBlankSide
 	}
 	if o.CancelAfter != "" && o.TimeInForce != GTT {
 		return errCancelAfterWithoutGTT

--- a/v2/testdata/BTC-USD-sell-false.json
+++ b/v2/testdata/BTC-USD-sell-false.json
@@ -1,0 +1,17 @@
+{
+    "id": "d0c5340b-6d6c-49d9-b567-48c4bfca13d2",
+    "price": "0.10000000",
+    "size": "0.01000000",
+    "product_id": "BTC-USD",
+    "side": "sell",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2016-12-08T20:02:28.53864Z",
+    "fill_fees": "0.0000000000000000",
+    "filled_size": "0.00000000",
+    "executed_value": "0.0000000000000000",
+    "status": "pending",
+    "settled": false
+}


### PR DESCRIPTION
Previously it'd be left upto GDAX's API server to decide
what side to set for an order. However, now ensure that no
blank side is sent. This makes the API restrictive but
deterministic.